### PR TITLE
Prevent dragging and zooming

### DIFF
--- a/html/src/main/webapp/index.html
+++ b/html/src/main/webapp/index.html
@@ -23,23 +23,25 @@
     <title>The Social Startup Game</title>
     <style>
         @font-face {
-        font-family: "Lato-Regular";
-        src: url(sim/fonts/Lato-Regular.ttf);
+          font-family: "Lato-Regular";
+          src: url(sim/fonts/Lato-Regular.ttf);
         }
         html,body {
-        width: 100%;
-        height: 100%;
+          margin: 0px;
+          overflow-y: hidden;
+          width: 100%;
+          height: 100%;
         }
         #playn-root {
-        width: 100%;
-        height: 100%;
+          width: 100%;
+          height: 100%;
         }
     </style>
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <link rel="apple-touch-icon" href="touch-icon.png">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
     <link rel="manifest" href="manifest.json">
 


### PR DESCRIPTION
This fixes #69 with a couple of tricks. First, the margins are set to 0px to override mobile Chrome's user agent default of 8px. Then, the additional vertical space is hidden with overflow-y in the css. Zooming is prevented via the viewport meta content.
